### PR TITLE
Potential fix for code scanning alert no. 739: `TrustManager` that accepts all certificates

### DIFF
--- a/src/sdk/java/src/main/java/Utils.java
+++ b/src/sdk/java/src/main/java/Utils.java
@@ -50,28 +50,7 @@ import org.threeten.extra.PeriodDuration;
 public class Utils {
     private static final Logger LOGGER = Logger.getLogger(Utils.class.getName());
 
-    public static void disableSSLVerification() throws Exception {
-        LOGGER.log(Level.WARNING, "SSL verification is disabled. This is insecure and should only be used in development environments.");
-        TrustManager[] trustAllCerts = new TrustManager[] {new X509TrustManager() {
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return null;
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] certs, String authType) {}
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] certs, String authType) {}
-        }};
-
-        SSLContext sc = SSLContext.getInstance("TLS");
-        sc.init(null, trustAllCerts, new java.security.SecureRandom());
-        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-
-        HostnameVerifier allHostsValid = (hostname, session) -> true;
-        HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
-    }
+// Removed the insecure disableSSLVerification method to prevent misuse and enhance security.
 
     public static void configureSSLCertificates(String caCertFilePath, String clientCertFilePath, String clientCertKeyFilePath)
             throws Exception {


### PR DESCRIPTION
Potential fix for [https://github.com/laoshanxi/app-mesh/security/code-scanning/739](https://github.com/laoshanxi/app-mesh/security/code-scanning/739)

To fix the issue, we will remove the insecure `disableSSLVerification` method entirely. If disabling SSL verification is absolutely necessary for development purposes, it should be implemented in a safer way, such as by requiring explicit configuration or environment variables to enable it. However, this functionality should not exist in production code.

Additionally, we will ensure that the `configureSSLCertificates` method is used as the secure alternative for managing SSL/TLS connections, as it already provides a mechanism to configure trusted certificates.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
